### PR TITLE
Fix for custom fontDir

### DIFF
--- a/load_font.php
+++ b/load_font.php
@@ -57,10 +57,11 @@ if ( $_SERVER["argc"] < 3 && @$_SERVER["argv"][1] != "system_fonts" ) {
   usage();
 }
 
-$dompdf = new Dompdf();
+$options = new Options();
 if (isset($fontDir) && realpath($fontDir) !== false) {
-  $dompdf->getOptions()->set('fontDir', $fontDir);
+  $options->set('fontDir', $fontDir);
 }
+$dompdf = new Dompdf($options);
 
 /**
  * Installs a new font family


### PR DESCRIPTION
Custom font directory must set through Dompdf constructor in order to retain previously loaded fonts
I think this fixes both #3 and #6.